### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/cmolinae1800/92d96715-218b-41ac-9ea1-aeccb02f74d5/2b6623e3-e642-4638-a452-82297dfe46b8/_apis/work/boardbadge/d2f04b77-5f4d-4040-ac1a-6dd5f826ea3b)](https://dev.azure.com/cmolinae1800/92d96715-218b-41ac-9ea1-aeccb02f74d5/_boards/board/t/2b6623e3-e642-4638-a452-82297dfe46b8/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/cmolinae1800/92d96715-218b-41ac-9ea1-aeccb02f74d5/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.